### PR TITLE
Add metatable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ This strict separation ensures **safe and predictable behavior** in embedded con
 ### Limitations
 - Unsupported Features:
 	- userdata, thread, and coroutines
-	- Metatables
 	- Closures
 	- Attributes
 

--- a/src/interpreter/ExtFunction.ts
+++ b/src/interpreter/ExtFunction.ts
@@ -1,6 +1,12 @@
 import { ParserRuleContext } from 'antlr4';
 import { ExtFunctionError, RuntimeError } from './errors';
-import { InternalListValue, InterpreterValue, NilValue, Value } from './types';
+import {
+  InternalListValue,
+  InterpreterValue,
+  NilValue,
+  TableValue,
+  Value,
+} from './types';
 import LuaInterpreter from './LuaInterpreter';
 
 export default class ExtFunction extends Value {
@@ -68,5 +74,9 @@ export default class ExtFunction extends Value {
 
   toString(): string {
     return `extFun:${this.name}:${this.uuid}`;
+  }
+
+  getMetatable(): TableValue | NilValue {
+    return new NilValue();
   }
 }

--- a/src/interpreter/LuaInterpreter.ts
+++ b/src/interpreter/LuaInterpreter.ts
@@ -1,82 +1,82 @@
 import LuaParserVisitor from '../parser/LuaParserVisitor';
 import {
-  Start_Context,
-  ChunkContext,
-  BlockContext,
-  Stat_no_opContext,
-  Stat_assing_varsContext,
-  Stat_function_callContext,
-  Stat_labelContext,
-  Stat_breakContext,
-  Stat_gotoContext,
-  Stat_doContext,
-  Stat_whileContext,
-  Stat_repeatContext,
-  Stat_ifContext,
-  Stat_for_varContext,
-  Stat_for_listContext,
-  Stat_functionContext,
-  Stat_local_functionContext,
-  Stat_local_attnamelistContext,
+  Args_exp_listContext,
+  Args_stringContext,
+  Args_table_constructorContext,
   AttnamelistContext,
   AttribContext,
-  RetstatContext,
-  LabelContext,
-  FuncnameContext,
-  VarlistContext,
-  NamelistContext,
-  ExplistContext,
-  Exp_trueContext,
-  Exp_bitsContext,
+  BlockContext,
+  ChunkContext,
   Exp_andContext,
-  Exp_stringContext,
   Exp_arithmetic_highContext,
-  Exp_relContext,
-  Stat_table_construnctorContext,
-  Exp_unaryContext,
-  Exp_orContext,
-  Exp_falseContext,
-  Stat_prefix_expContext,
-  Exp_exponentContext,
-  Exp_numberContext,
-  Exp_concatContext,
-  Exp_varargContext,
   Exp_arithmetic_lowContext,
+  Exp_bitsContext,
+  Exp_concatContext,
+  Exp_exponentContext,
+  Exp_falseContext,
   Exp_function_defContext,
   Exp_nilContext,
-  Var_nameContext,
-  Var_expContext,
-  Prefixexp_nameContext,
-  Prefixexp_function_callContext,
-  Prefixexp_expContext,
-  Fcall_nameContext,
-  Fcall_name_extContext,
-  Fcall_function_callContext,
-  Fcall_expContext,
+  Exp_numberContext,
+  Exp_orContext,
+  Exp_relContext,
+  Exp_stringContext,
+  Exp_trueContext,
+  Exp_unaryContext,
+  Exp_varargContext,
+  ExpContext,
+  ExplistContext,
   Fcall_exp_extContext,
+  Fcall_expContext,
   Fcall_function_call_extContext,
-  Args_exp_listContext,
-  Args_table_constructorContext,
-  Args_stringContext,
-  FunctiondefContext,
-  FuncbodyContext,
-  Parlist_namellistContext,
-  Parlist_varargContext,
-  Parlist_noneContext,
-  TableconstructorContext,
-  FieldlistContext,
+  Fcall_function_callContext,
+  Fcall_name_extContext,
+  Fcall_nameContext,
   Field_exp_expContext,
-  Field_name_expContext,
   Field_expContext,
+  Field_name_expContext,
+  FieldlistContext,
   FieldsepContext,
-  Number_intContext,
-  Number_hexContext,
+  FuncbodyContext,
+  FuncnameContext,
+  FunctiondefContext,
+  LabelContext,
+  NamelistContext,
   Number_floatContext,
   Number_hex_floatContext,
-  String_stringContext,
+  Number_hexContext,
+  Number_intContext,
+  Parlist_namellistContext,
+  Parlist_noneContext,
+  Parlist_varargContext,
+  Prefixexp_expContext,
+  Prefixexp_function_callContext,
+  Prefixexp_nameContext,
+  RetstatContext,
+  Start_Context,
+  Stat_assing_varsContext,
+  Stat_breakContext,
+  Stat_doContext,
+  Stat_for_listContext,
+  Stat_for_varContext,
+  Stat_function_callContext,
+  Stat_functionContext,
+  Stat_gotoContext,
+  Stat_ifContext,
+  Stat_labelContext,
+  Stat_local_attnamelistContext,
+  Stat_local_functionContext,
+  Stat_no_opContext,
+  Stat_prefix_expContext,
+  Stat_repeatContext,
+  Stat_table_construnctorContext,
+  Stat_whileContext,
   String_charstringContext,
   String_longstringContext,
-  ExpContext,
+  String_stringContext,
+  TableconstructorContext,
+  Var_expContext,
+  Var_nameContext,
+  VarlistContext,
 } from '../parser/LuaParser';
 import {
   BooleanValue,
@@ -467,6 +467,30 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     const left = firstValue(ctx.exp(0).accept(this));
     const right = firstValue(ctx.exp(1).accept(this));
 
+    let op: string;
+    if (ctx.AMP()) {
+      op = '__band';
+    } else if (ctx.PIPE()) {
+      op = '__bor';
+    } else if (ctx.SQUIG()) {
+      op = '__bxor';
+    } else if (ctx.GG()) {
+      op = '__shr';
+    } else {
+      op = '__shl';
+    }
+
+    const metatableOperation =
+      getMetatableOperation(left, op) || getMetatableOperation(right, op);
+
+    if (metatableOperation) {
+      return this.exec_function(
+        metatableOperation,
+        new InternalListValue([left, right]),
+        ctx
+      );
+    }
+
     if (!(left instanceof NumberValue)) {
       throw new RuntimeError(
         `Expected NumberValue, but got ${left.constructor.name}`,
@@ -511,6 +535,29 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     const left = firstValue(ctx.exp(0).accept(this));
     const right = firstValue(ctx.exp(1).accept(this));
 
+    let op: string;
+    if (ctx.STAR()) {
+      op = '__mul';
+    } else if (ctx.SLASH()) {
+      op = '__div';
+    } else if (ctx.PER()) {
+      op = '__mod';
+    } else if (ctx.SS()) {
+      op = '__idiv';
+    } else {
+      throw new NotYetImplemented('will never happen', ctx, 'N999');
+    }
+    const metatableOperation =
+      getMetatableOperation(left, op) || getMetatableOperation(right, op);
+
+    if (metatableOperation) {
+      return this.exec_function(
+        metatableOperation,
+        new InternalListValue([left, right]),
+        ctx
+      );
+    }
+
     if (!(left instanceof NumberValue)) {
       throw new RuntimeError(
         `Expected NumberValue, but got ${left.constructor.name}`,
@@ -542,10 +589,10 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     const left = firstValue(ctx.exp(0).accept(this));
     const right = firstValue(ctx.exp(1).accept(this));
     if (ctx.EE()) {
-      return this.compare_ee(left, right);
+      return this.compare_ee(left, right, ctx);
     }
     if (ctx.SQEQ()) {
-      return BooleanValue.from(!this.compare_ee(left, right).boolean);
+      return BooleanValue.from(!this.compare_ee(left, right, ctx).boolean);
     }
     if (ctx.LT()) {
       return this.compare_lt(left, right, ctx, false);
@@ -569,6 +616,23 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     le: boolean
   ): BooleanValue {
     this.consumeCredit(ctx);
+
+    const op = le ? '__le' : '__lt';
+    const metatableOperation =
+      getMetatableOperation(left, op) || getMetatableOperation(right, op);
+
+    if (metatableOperation) {
+      return BooleanValue.from(
+        isTrue(
+          this.exec_function(
+            metatableOperation,
+            new InternalListValue([left, right]),
+            ctx
+          )
+        )
+      );
+    }
+
     if (left instanceof NumberValue) {
       if (!(right instanceof NumberValue)) {
         throw new RuntimeError(
@@ -597,7 +661,15 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     }
   }
 
-  private compare_ee(left: Value, right: Value): BooleanValue {
+  private compare_ee(
+    left: Value,
+    right: Value,
+    ctx: ParserRuleContext
+  ): BooleanValue {
+    const op = '__eq';
+    const metatableOperation =
+      getMetatableOperation(left, op) || getMetatableOperation(right, op);
+
     if (left.constructor != right.constructor) {
       return BooleanValue.false();
     } else if (
@@ -617,9 +689,20 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
       return BooleanValue.true();
     } else if (left instanceof NilValue && right instanceof NilValue) {
       return BooleanValue.true();
-    } else {
-      return BooleanValue.from(left == right);
+    } else if (left == right) {
+      return BooleanValue.true();
+    } else if (metatableOperation) {
+      return BooleanValue.from(
+        isTrue(
+          this.exec_function(
+            metatableOperation,
+            new InternalListValue([left, right]),
+            ctx
+          )
+        )
+      );
     }
+    return BooleanValue.false();
   }
 
   visitStat_table_construnctor = (
@@ -633,8 +716,16 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     this.consumeCredit(ctx);
     const exp = firstValue(ctx.exp().accept(this));
     if (ctx.MINUS()) {
+      const metatableOperation = getMetatableOperation(exp, '__unm');
+
       if (exp instanceof NumberValue) {
         return new NumberValue(-1 * (exp as NumberValue).number);
+      } else if (metatableOperation) {
+        return this.exec_function(
+          metatableOperation,
+          new InternalListValue([exp, exp]),
+          ctx
+        );
       } else {
         throw new RuntimeError(
           `expecting number, but got ${exp.constructor.name}`,
@@ -644,8 +735,16 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     } else if (ctx.NOT()) {
       return BooleanValue.from(!isTrue(exp));
     } else if (ctx.POUND()) {
+      const metatableOperation = getMetatableOperation(exp, '__len');
+
       if (exp instanceof StringValue) {
         return NumberValue.from((exp as StringValue).string.length);
+      } else if (metatableOperation) {
+        return this.exec_function(
+          metatableOperation,
+          new InternalListValue([exp, exp]),
+          ctx
+        );
       } else if (exp instanceof TableValue) {
         return NumberValue.from((exp as TableValue).size());
       } else {
@@ -655,8 +754,16 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
         );
       }
     } else if (ctx.SQUIG()) {
+      const metatableOperation = getMetatableOperation(exp, '__bnot');
+
       if (exp instanceof NumberValue) {
         return NumberValue.from(~(exp as NumberValue).number);
+      } else if (metatableOperation) {
+        return this.exec_function(
+          metatableOperation,
+          new InternalListValue([exp, exp]),
+          ctx
+        );
       } else {
         throw new RuntimeError(
           `expecting number, but got ${exp.constructor.name}`,
@@ -689,6 +796,18 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     const left = firstValue(ctx.exp(0).accept(this));
     const right = firstValue(ctx.exp(1).accept(this));
 
+    const op = '__pow';
+    const metatableOperation =
+      getMetatableOperation(left, op) || getMetatableOperation(right, op);
+
+    if (metatableOperation) {
+      return this.exec_function(
+        metatableOperation,
+        new InternalListValue([left, right]),
+        ctx
+      );
+    }
+
     if (!(left instanceof NumberValue)) {
       throw new RuntimeError(
         `Expected NumberValue, but got ${left.constructor.name}`,
@@ -715,6 +834,19 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     this.consumeCredit(ctx);
     const left = firstValue(ctx.exp(0).accept(this));
     const right = firstValue(ctx.exp(1).accept(this));
+
+    const op = '__concat';
+    const metatableOperation =
+      getMetatableOperation(left, op) || getMetatableOperation(right, op);
+
+    if (metatableOperation) {
+      return this.exec_function(
+        metatableOperation,
+        new InternalListValue([left, right]),
+        ctx
+      );
+    }
+
     return StringValue.from(
       this.valueToString(left) + this.valueToString(right)
     );
@@ -756,6 +888,19 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     this.consumeCredit(ctx);
     const left = firstValue(ctx.exp(0).accept(this));
     const right = firstValue(ctx.exp(1).accept(this));
+
+    const op = ctx.PLUS() ? '__add' : '__sub';
+    const metatableOperation =
+      getMetatableOperation(left, op) || getMetatableOperation(right, op);
+
+    if (metatableOperation) {
+      return this.exec_function(
+        metatableOperation,
+        new InternalListValue([left, right]),
+        ctx
+      );
+    }
+
     if (!(left instanceof NumberValue)) {
       throw new RuntimeError(
         `Expected NumberValue, but got ${left.constructor.name}`,
@@ -808,9 +953,50 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
       ? StringValue.from(ctx.NAME().getText())
       : firstValue(ctx.exp().accept(this));
     return new InternalVar(v => {
-      (top as TableValue).set(key, v);
+      this.setTableValue(top as TableValue, key, v, ctx);
     });
   };
+
+  private setTableValue(
+    table: TableValue,
+    key: Value,
+    value: Value,
+    ctx: ParserRuleContext
+  ): void {
+    const oldVal = table.get(key);
+    if (!(oldVal instanceof NilValue)) {
+      table.set(key, value);
+      return;
+    }
+
+    const metamethodOrTable = getMetatableField(table, '__newindex');
+    if (metamethodOrTable instanceof NilValue) {
+      table.set(key, value);
+      return;
+    }
+
+    if (
+      metamethodOrTable instanceof FunctionValue ||
+      metamethodOrTable instanceof ExtFunction
+    ) {
+      this.exec_function(
+        metamethodOrTable,
+        new InternalListValue([table, key, value]),
+        ctx
+      );
+      return;
+    }
+
+    if (metamethodOrTable instanceof TableValue) {
+      this.setTableValue(metamethodOrTable, key, value, ctx);
+      return;
+    }
+
+    throw new RuntimeError(
+      `__newindex must be a function or table, got ${metamethodOrTable.constructor.name}`,
+      ctx
+    );
+  }
 
   visitPrefixexp_name = (ctx: Prefixexp_nameContext): Value => {
     this.consumeCredit(ctx);
@@ -905,6 +1091,59 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
       : this.exec_ext_function(f as ExtFunction, args, ctx);
   }
 
+  exec_setmetatable(list_args: InternalListValue, ctx: Fcall_nameContext) {
+    const table = list_args.get(1);
+    const metatable = list_args.get(2);
+
+    if (!(table instanceof TableValue)) {
+      // throw new RuntimeError(`Cannot execute setmetatable on non-table value ${table}`, ctx)
+      return new NilValue();
+    }
+
+    if (
+      !(metatable instanceof TableValue) &&
+      !(metatable instanceof NilValue)
+    ) {
+      throw new RuntimeError(
+        `Cannot execute setmetatable on non-table metatable ${metatable}`,
+        ctx
+      );
+    }
+
+    table.setMetatable(metatable);
+    return new NilValue();
+  }
+
+  exec_getmetatable(list_args: InternalListValue) {
+    const table = list_args.get(1);
+
+    return table.getMetatable();
+  }
+
+  private callValue(
+    value: Value,
+    args: InternalListValue,
+    ctx: ParserRuleContext
+  ): Value {
+    if (value instanceof ExtFunction) {
+      return this.exec_ext_function(value as ExtFunction, args, ctx);
+    } else if (value instanceof FunctionValue) {
+      return this.exec_lua_function(value as FunctionValue, args);
+    }
+
+    const metamethod = getMetatableField(value, '__call');
+    if (!(metamethod instanceof NilValue)) {
+      const callArgs = args.asList();
+      callArgs.unshift(value);
+      return this.callValue(metamethod, new InternalListValue(callArgs), ctx);
+    }
+
+    throw new RuntimeError(
+      `Can't execute non-function: ${value.constructor.name}`,
+      ctx
+    );
+  }
+
   visitFcall_name = (ctx: Fcall_nameContext): Value => {
     this.consumeCredit(ctx);
     const fname = ctx.NAME(0).getText();
@@ -918,16 +1157,13 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
       ctx
     );
     const list_args = ctx.args().accept(this) as InternalListValue;
-    if (value instanceof ExtFunction) {
-      return this.exec_ext_function(value as ExtFunction, list_args, ctx);
-    } else if (value instanceof FunctionValue) {
-      return this.exec_lua_function(value as FunctionValue, list_args);
-    } else {
-      throw new RuntimeError(
-        `Can't execute non-function: ${value.constructor.name}`,
-        ctx
-      );
+    if (fname === 'setmetatable') {
+      return this.exec_setmetatable(list_args, ctx);
     }
+    if (fname === 'getmetatable') {
+      return this.exec_getmetatable(list_args);
+    }
+    return this.callValue(value, list_args, ctx);
   };
 
   private walkExpAndName(
@@ -953,22 +1189,58 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
       }
       const child = ctx.getChild(i);
       const childText = child.getText();
+      let key: Value;
       if (childText === '.') {
-        value = (value as TableValue).get(
-          StringValue.from(names[nameIndex].getText())
-        );
+        key = StringValue.from(names[nameIndex].getText());
         nameIndex++;
         i += 2;
       } else if (childText === '[') {
-        const exp = exps[expIndex].accept(this);
+        key = exps[expIndex].accept(this);
         expIndex++;
         i += 3;
-        value = (value as TableValue).get(exp);
       } else {
         break;
       }
+
+      value = this.getTableValue(value as TableValue, key, ctx);
     }
     return value;
+  }
+
+  private getTableValue(
+    table: TableValue,
+    key: Value,
+    ctx: ParserRuleContext
+  ): Value {
+    const res = table.get(key);
+    if (!(res instanceof NilValue)) {
+      return res;
+    }
+
+    const metamethodOrTable = getMetatableField(table, '__index');
+    if (metamethodOrTable instanceof NilValue) {
+      return res;
+    }
+
+    if (
+      metamethodOrTable instanceof FunctionValue ||
+      metamethodOrTable instanceof ExtFunction
+    ) {
+      return this.exec_function(
+        metamethodOrTable,
+        new InternalListValue([table, key]),
+        ctx
+      );
+    }
+
+    if (metamethodOrTable instanceof TableValue) {
+      return this.getTableValue(metamethodOrTable, key, ctx);
+    }
+
+    throw new RuntimeError(
+      `__index must be a function or table, got ${metamethodOrTable.constructor.name}`,
+      ctx
+    );
   }
 
   visitFcall_name_ext = (ctx: Fcall_name_extContext): Value => {
@@ -994,17 +1266,7 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     const fun = (table as TableValue).get(StringValue.from(fName));
     const list_args = (ctx.args().accept(this) as InternalListValue).asList();
     list_args.unshift(table);
-    const args = new InternalListValue(list_args);
-    if (fun instanceof ExtFunction) {
-      return this.exec_ext_function(fun as ExtFunction, args, ctx);
-    } else if (fun instanceof FunctionValue) {
-      return this.exec_lua_function(fun as FunctionValue, args);
-    } else {
-      throw new RuntimeError(
-        `Can't execute non-function: ${fun.constructor.name}`,
-        ctx
-      );
-    }
+    return this.callValue(fun, new InternalListValue(list_args), ctx);
   };
 
   visitFcall_function_call = (ctx: Fcall_function_callContext): Value => {
@@ -1021,16 +1283,7 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
       )
     );
     const list_args = ctx.args().accept(this) as InternalListValue;
-    if (fun instanceof ExtFunction) {
-      return this.exec_ext_function(fun as ExtFunction, list_args, ctx);
-    } else if (fun instanceof FunctionValue) {
-      return this.exec_lua_function(fun as FunctionValue, list_args);
-    } else {
-      throw new RuntimeError(
-        `Can't execute non-function: ${fun.constructor.name}`,
-        ctx
-      );
-    }
+    return this.callValue(fun, list_args, ctx);
   };
 
   visitFcall_exp = (ctx: Fcall_expContext): Value => {
@@ -1047,16 +1300,7 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
       )
     );
     const list_args = ctx.args().accept(this) as InternalListValue;
-    if (fun instanceof ExtFunction) {
-      return this.exec_ext_function(fun as ExtFunction, list_args, ctx);
-    } else if (fun instanceof FunctionValue) {
-      return this.exec_lua_function(fun as FunctionValue, list_args);
-    } else {
-      throw new RuntimeError(
-        `Can't execute non-function: ${fun.constructor.name}`,
-        ctx
-      );
-    }
+    return this.callValue(fun, list_args, ctx);
   };
 
   visitFcall_exp_ext = (ctx: Fcall_exp_extContext): Value => {
@@ -1082,17 +1326,7 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     const fun = (table as TableValue).get(StringValue.from(fName));
     const list_args = (ctx.args().accept(this) as InternalListValue).asList();
     list_args.unshift(table);
-    const args = new InternalListValue(list_args);
-    if (fun instanceof ExtFunction) {
-      return this.exec_ext_function(fun as ExtFunction, args, ctx);
-    } else if (fun instanceof FunctionValue) {
-      return this.exec_lua_function(fun as FunctionValue, args);
-    } else {
-      throw new RuntimeError(
-        `Can't execute non-function: ${fun.constructor.name}`,
-        ctx
-      );
-    }
+    return this.callValue(fun, new InternalListValue(list_args), ctx);
   };
 
   visitFcall_function_call_ext = (
@@ -1120,17 +1354,7 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     const fun = (table as TableValue).get(StringValue.from(fName));
     const list_args = (ctx.args().accept(this) as InternalListValue).asList();
     list_args.unshift(table);
-    const args = new InternalListValue(list_args);
-    if (fun instanceof ExtFunction) {
-      return this.exec_ext_function(fun as ExtFunction, args, ctx);
-    } else if (fun instanceof FunctionValue) {
-      return this.exec_lua_function(fun as FunctionValue, args);
-    } else {
-      throw new RuntimeError(
-        `Can't execute non-function: ${fun.constructor.name}`,
-        ctx
-      );
-    }
+    return this.callValue(fun, new InternalListValue(list_args), ctx);
   };
 
   visitArgs_exp_list = (ctx: Args_exp_listContext): Value => {
@@ -1294,4 +1518,23 @@ export default class LuaInterpreter extends LuaParserVisitor<Value> {
     }
     return StringValue.from(text.substring(i, j + 1));
   };
+}
+
+function getMetatableOperation(
+  table: Value,
+  op: string
+): FunctionValue | ExtFunction | undefined {
+  const method = getMetatableField(table, op);
+  if (!(method instanceof FunctionValue) && !(method instanceof ExtFunction)) {
+    return;
+  }
+  return method;
+}
+
+function getMetatableField(table: Value, op: string): Value {
+  const metatable = table.getMetatable();
+  if (!(metatable instanceof TableValue)) {
+    return new NilValue();
+  }
+  return metatable.get(StringValue.from(op));
 }

--- a/src/interpreter/types.ts
+++ b/src/interpreter/types.ts
@@ -4,6 +4,7 @@ import LuaInterpreter from './LuaInterpreter';
 abstract class Value {
   abstract asIdString(): string;
   abstract toString(): string;
+  abstract getMetatable(): TableValue | NilValue;
 }
 
 class NilValue extends Value {
@@ -13,6 +14,10 @@ class NilValue extends Value {
 
   toString(): string {
     return 'nil';
+  }
+
+  getMetatable(): TableValue | NilValue {
+    return new NilValue();
   }
 }
 
@@ -40,6 +45,10 @@ class NumberValue extends Value {
   toString(): string {
     return this._number.toString();
   }
+
+  getMetatable(): TableValue | NilValue {
+    return new NilValue();
+  }
 }
 
 class StringValue extends Value {
@@ -66,12 +75,18 @@ class StringValue extends Value {
   toString(): string {
     return this._str;
   }
+
+  getMetatable(): TableValue | NilValue {
+    return new NilValue();
+  }
 }
 
 class TableValue extends Value {
   private readonly uuid = crypto.randomUUID();
   // ref to key mapped to [key, value]
   private readonly _table: Map<string, Value[]> = new Map<string, Value[]>();
+
+  private _metatable: TableValue | NilValue = new NilValue();
 
   get(key: Value): Value {
     const value = this._table.get(key.asIdString());
@@ -108,6 +123,14 @@ class TableValue extends Value {
 
   toString(): string {
     return this.asIdString();
+  }
+
+  setMetatable(metatable: TableValue | NilValue) {
+    this._metatable = metatable;
+  }
+
+  getMetatable(): TableValue | NilValue {
+    return this._metatable;
   }
 
   size(): number {
@@ -154,6 +177,10 @@ class BooleanValue extends Value {
   toString(): string {
     return this.value.toString();
   }
+
+  getMetatable(): TableValue | NilValue {
+    return new NilValue();
+  }
 }
 
 class FunctionValue extends Value {
@@ -182,6 +209,10 @@ class FunctionValue extends Value {
 
   toString(): string {
     return this.asIdString();
+  }
+
+  getMetatable(): TableValue | NilValue {
+    return new NilValue();
   }
 }
 
@@ -224,6 +255,10 @@ class InternalListValue extends Value {
   toString(): string {
     throw new Error('Not implemented');
   }
+
+  getMetatable(): TableValue | NilValue {
+    throw new Error('Not implemented');
+  }
 }
 
 class InternalPairValue extends Value {
@@ -263,6 +298,10 @@ class InternalPairValue extends Value {
   toString(): string {
     throw new Error('Not implemented');
   }
+
+  getMetatable(): TableValue | NilValue {
+    throw new Error('Not implemented');
+  }
 }
 
 class InternalVar extends Value {
@@ -284,6 +323,10 @@ class InternalVar extends Value {
   toString(): string {
     throw new Error('Not implemented');
   }
+
+  getMetatable(): TableValue | NilValue {
+    throw new Error('Not implemented');
+  }
 }
 
 class InterpreterValue extends Value {
@@ -302,6 +345,10 @@ class InterpreterValue extends Value {
   }
   toString(): string {
     throw new Error('Method not implemented.');
+  }
+
+  getMetatable(): TableValue | NilValue {
+    throw new Error('Not implemented');
   }
 }
 

--- a/tests/interpreter/metatable.test.ts
+++ b/tests/interpreter/metatable.test.ts
@@ -1,0 +1,285 @@
+import { VMBuilder } from '@src/vm';
+import { StringValue, TableValue } from '@src/interpreter/types';
+import {
+  expectToBeBool,
+  expectToBeNumber,
+  expectToBeString,
+  expectToBeNil,
+} from './test_utils';
+
+describe('metatable', () => {
+  test('arithmetic', () => {
+    const lua = `
+        meta = { }
+        meta.__add = function() return "add"; end
+        meta.__sub = function() return "sub"; end
+        meta.__mul = function() return "mul"; end
+        meta.__div = function() return "div"; end
+        meta.__mod = function() return "mod"; end
+        meta.__pow = function() return "pow"; end
+        meta.__unm = function() return "unm"; end
+        meta.__idiv = function() return "idiv"; end
+        
+        a = { id = "a" }
+        setmetatable(a, meta)
+        b = { id = "b" }
+        setmetatable(b, meta)
+        c = { id = "c" }
+        -- c without metatable
+        
+        r1 = a + b
+        r2 = 1 - b
+        r3 = a * 2
+        r4 = "x" / b
+        r5 = a % "y"
+        r6 = a ^ c
+        r7 = -a
+        r8 = c // b
+    `;
+
+    const result = new VMBuilder().build().executeOnce(lua);
+
+    expectToBeString(result.globalVar('r1'), 'add');
+    expectToBeString(result.globalVar('r2'), 'sub');
+    expectToBeString(result.globalVar('r3'), 'mul');
+    expectToBeString(result.globalVar('r4'), 'div');
+    expectToBeString(result.globalVar('r5'), 'mod');
+    expectToBeString(result.globalVar('r6'), 'pow');
+    expectToBeString(result.globalVar('r7'), 'unm');
+    expectToBeString(result.globalVar('r8'), 'idiv');
+  });
+
+  test('bitwise', () => {
+    const lua = `
+        meta = { }
+        meta.__band = function() return "band"; end
+        meta.__bor = function() return "bor"; end
+        meta.__bxor = function() return "bxor"; end
+        meta.__shl = function() return "shl"; end
+        meta.__shr = function() return "shr"; end
+        meta.__bnot = function() return "bnot"; end
+        
+        a = { id = "a" }
+        setmetatable(a, meta)
+        b = { id = "b" }
+        setmetatable(b, meta)
+        
+        r1 = a & b
+        r2 = a | 3.14
+        r3 = 7 ~ b
+        r4 = a << "message"
+        r5 = a >> 1
+        r6 = ~a
+    `;
+
+    const result = new VMBuilder().build().executeOnce(lua);
+
+    expectToBeString(result.globalVar('r1'), 'band');
+    expectToBeString(result.globalVar('r2'), 'bor');
+    expectToBeString(result.globalVar('r3'), 'bxor');
+    expectToBeString(result.globalVar('r4'), 'shl');
+    expectToBeString(result.globalVar('r5'), 'shr');
+    expectToBeString(result.globalVar('r6'), 'bnot');
+  });
+
+  test('comparison', () => {
+    const lua = `
+        log = ""
+        meta = { }
+        meta.__eq = function() log = log .. "eq"; return "eq"; end
+        meta.__lt = function() log = log .. "lt"; return nil; end
+        meta.__le = function() log = log .. "le"; return false; end
+        
+        a = { id = "a" }
+        setmetatable(a, meta)
+        b = { id = "b" }
+        setmetatable(b, meta)
+        
+        r1 = a == b
+        r2 = a < b
+        r3 = a <= b
+        r4 = a > b
+        r5 = a >= b
+    `;
+
+    const result = new VMBuilder().build().executeOnce(lua);
+
+    expectToBeBool(result.globalVar('r1'), true);
+    expectToBeBool(result.globalVar('r2'), false);
+    expectToBeBool(result.globalVar('r3'), false);
+    expectToBeBool(result.globalVar('r4'), false); // a > b is b < a
+    expectToBeBool(result.globalVar('r5'), false); // a >= b is b <= a
+    expectToBeString(result.globalVar('log'), 'eqltleltle');
+  });
+
+  test('index', () => {
+    const lua = `
+        t = { a = 1 }
+        meta = {
+            __index = function(table, key)
+                if key == "b" then return 2 end
+                return "fallback"
+            end
+        }
+        setmetatable(t, meta)
+        
+        r1 = t.a
+        r2 = t.b
+        r3 = t.c
+        
+        t2 = {}
+        meta2 = { __index = { x = 10, y = 20 } }
+        setmetatable(t2, meta2)
+        
+        r4 = t2.x
+        r5 = t2.z
+
+        -- recursive table index
+        t3 = {}
+        meta3 = { __index = t2 }
+        setmetatable(t3, meta3)
+        r6 = t3.x
+        r7 = t3.y
+        r8 = t3.z
+    `;
+
+    const result = new VMBuilder().build().executeOnce(lua);
+
+    expectToBeNumber(result.globalVar('r1'), 1);
+    expectToBeNumber(result.globalVar('r2'), 2);
+    expectToBeString(result.globalVar('r3'), 'fallback');
+    expectToBeNumber(result.globalVar('r4'), 10);
+    expectToBeNil(result.globalVar('r5'));
+    expectToBeNumber(result.globalVar('r6'), 10);
+    expectToBeNumber(result.globalVar('r7'), 20);
+    expectToBeNil(result.globalVar('r8'));
+  });
+
+  test('newindex', () => {
+    const lua = `
+        t = { a = 1 }
+        log = ""
+        meta = {
+            __newindex = function(table, key, value)
+                log = log .. key .. "=" .. value .. ";"
+            end
+        }
+        setmetatable(t, meta)
+        
+        t.a = 10
+        t.b = 20
+        t.c = "val"
+        
+        r1 = t.a
+        r2 = t.b
+        
+        t2 = {}
+        target = {}
+        setmetatable(t2, { __newindex = target })
+        
+        t2.foo = "bar"
+        r3 = target.foo
+        r4 = t2.foo
+
+        -- recursive table newindex
+        t3 = {}
+        setmetatable(t3, { __newindex = t2 })
+        t3.baz = 42
+        r5 = target.baz
+        r6 = t3.baz
+    `;
+
+    const result = new VMBuilder().build().executeOnce(lua);
+
+    expectToBeNumber(result.globalVar('r1'), 10); // should be updated in t because it existed
+    expectToBeNil(result.globalVar('r2')); // should NOT be updated in t
+    expectToBeString(result.globalVar('log'), 'b=20;c=val;');
+    expectToBeString(result.globalVar('r3'), 'bar');
+    expectToBeNil(result.globalVar('r4'));
+    expectToBeNumber(result.globalVar('r5'), 42);
+    expectToBeNil(result.globalVar('r6'));
+  });
+
+  test('call', () => {
+    const lua = `
+        t = { x = 10 }
+        meta = {
+            __call = function(table, a, b)
+                return table.x + a + b
+            end
+        }
+        setmetatable(t, meta)
+        
+        r1 = t(1, 2)
+        
+        t2 = {}
+        meta2 = {
+            __call = function(table, a, b)
+                return a + b + 100
+            end
+        }
+        setmetatable(t2, meta2)
+        r2 = t2(1, 2)
+
+        -- recursive call
+        log = ""
+        t_base = {}
+        setmetatable(t_base, { __call = function(s, val) log = log .. "called"; end })
+        
+        t_rec = {}
+        setmetatable(t_rec, { __call = t_base })
+        
+        t_rec("A")
+    `;
+
+    const result = new VMBuilder().build().executeOnce(lua);
+
+    expectToBeNumber(result.globalVar('r1'), 13);
+    expectToBeNumber(result.globalVar('r2'), 103);
+    expectToBeString(result.globalVar('log'), 'called');
+  });
+
+  test('other', () => {
+    const lua = `
+        meta = { }
+        meta.__concat = function() return "concat"; end
+        meta.__len = function() return "len"; end
+        
+        a = { id = "a" }
+        setmetatable(a, meta)
+        b = { id = "b" }
+        setmetatable(b, meta)
+        
+        r1 = a .. b
+        r2 = a .. "x"
+        r3 = 1 .. b
+        r4 = #a
+    `;
+
+    const result = new VMBuilder().build().executeOnce(lua);
+
+    expectToBeString(result.globalVar('r1'), 'concat');
+    expectToBeString(result.globalVar('r2'), 'concat');
+    expectToBeString(result.globalVar('r3'), 'concat');
+    expectToBeString(result.globalVar('r4'), 'len');
+  });
+
+  test('getmetatable', () => {
+    const lua = `
+        t = {}
+        m = { name = "meta" }
+        setmetatable(t, m)
+        r1 = getmetatable(t)
+        r2 = r1 == m
+        r3 = getmetatable({})
+    `;
+
+    const result = new VMBuilder().build().executeOnce(lua);
+
+    const r1 = result.globalVar('r1');
+    expect(r1).toBeInstanceOf(TableValue);
+    expectToBeString((r1 as TableValue).get(StringValue.from('name')), 'meta');
+    expectToBeBool(result.globalVar('r2'), true);
+    expectToBeNil(result.globalVar('r3'));
+  });
+});


### PR DESCRIPTION
This pull request introduces support for Lua metatables in the interpreter, enabling key Lua behaviors such as operator overloading, custom indexing, and metamethods for tables. The changes include implementing metatable storage and retrieval on `TableValue`, adding a `getMetatable` method to all value types, and comprehensive tests to ensure correct metatable functionality across arithmetic, bitwise, comparison, indexing, and other operations.

**Metatable support and value type changes:**

* Added a `getMetatable(): TableValue | NilValue` method to the abstract `Value` class and implemented it in all subclasses, returning either the associated metatable (for `TableValue`) or `nil`/throwing an error as appropriate for other types. (`src/interpreter/types.ts` [[1]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R7) [[2]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R18-R21) [[3]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R48-R51) [[4]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R78-R90) [[5]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R128-R135) [[6]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R180-R183) [[7]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R213-R216) [[8]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R258-R261) [[9]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R301-R304) [[10]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R326-R329) [[11]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R349-R352); `src/interpreter/ExtFunction.ts` [[12]](diffhunk://#diff-c8dbfa8c948001aa63561f5aa087e76fa109be271ce694520047f9690be0c791L3-R9) [[13]](diffhunk://#diff-c8dbfa8c948001aa63561f5aa087e76fa109be271ce694520047f9690be0c791R78-R81)

* Implemented metatable storage on `TableValue`, with `setMetatable` and `getMetatable` methods, allowing tables to have and use metatables as in standard Lua. (`src/interpreter/types.ts` [[1]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R78-R90) [[2]](diffhunk://#diff-5ef2f4c97289b0d81ed270a84fb8169266987b70688091200d2b8663e77eb088R128-R135)

**Testing and documentation:**

* Added a comprehensive test suite covering all major metatable behaviors, including arithmetic, bitwise, comparison, indexing, newindex, call, concat, len, and `getmetatable`/`setmetatable` functions, ensuring correctness and compatibility with Lua semantics. (`tests/interpreter/metatable.test.ts` [tests/interpreter/metatable.test.tsR1-R285](diffhunk://#diff-2191604ac9c2016e70fa96cc39ed9f2d580000475420c24d13c79b971317f2b1R1-R285))

* Updated the documentation to remove "Metatables" from the list of unsupported features, reflecting that metatable support is now implemented. (`README.md` [README.mdL47](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47))